### PR TITLE
Some improvements, esp. for Javadoc hovers and views

### DIFF
--- a/fix-eclipse-ubuntu-16.04-laf.sh
+++ b/fix-eclipse-ubuntu-16.04-laf.sh
@@ -71,6 +71,9 @@ sed -i -r -e 's/@define-color tooltip_bg_color.*/@define-color tooltip_bg_color 
 	  -e 's/@define-color tooltip_fg_color.*/@define-color tooltip_fg_color #000000;/'\
 		$ECLIPSE_THEME_DIR/gtk-3.0/gtk-main.css
 
+# also copy Default theme (somehow needed to keep button border
+# animations the same)
+cp -rf /usr/share/themes/Default $ECLIPSE_THEME_DIR/../
 
 # create Eclipse launch menu
 LAUNCH_FILENAME="eclipse_$ECLIPSE_VERS.desktop"

--- a/fix-eclipse-ubuntu-16.04-laf.sh
+++ b/fix-eclipse-ubuntu-16.04-laf.sh
@@ -50,6 +50,9 @@ fi
 ECLIPSE_VERS=`grep version $ECLIPSE_HOME/.eclipseproduct | sed 's/version=//'`
 DATE=`date|tr ' ' '_'`
 
+# Fetch location of desktop directory
+DESKTOP_DIR=$(xdg-user-dir DESKTOP)
+
 # Directory where the modified Ambiance-Eclipse theme is stored.
 ECLIPSE_THEME_ROOT_DIR=$HOME/.eclipse/share/themes
 ECLIPSE_THEME_DIR=$ECLIPSE_THEME_ROOT_DIR/Ambiance-Eclipse
@@ -71,12 +74,12 @@ sed -i -r -e 's/@define-color tooltip_bg_color.*/@define-color tooltip_bg_color 
 
 # create Eclipse launch menu
 LAUNCH_FILENAME="eclipse_$ECLIPSE_VERS.desktop"
-if [ -f $HOME/Desktop/$LAUNCH_FILENAME ]; then
-	mv $HOME/Desktop/$LAUNCH_FILENAME $HOME/Desktop/$LAUNCH_FILENAME.b4_$DATE
+if [ -f $DESKTOP_DIR/$LAUNCH_FILENAME ]; then
+	mv $DESKTOP_DIR/$LAUNCH_FILENAME $DESKTOP_DIR/$LAUNCH_FILENAME.b4_$DATE
 fi
-touch $HOME/Desktop/$LAUNCH_FILENAME
+touch $DESKTOP_DIR/$LAUNCH_FILENAME
 
-cat > $HOME/Desktop/$LAUNCH_FILENAME << endtext
+cat > $DESKTOP_DIR/$LAUNCH_FILENAME << endtext
 [Desktop Entry]
 Version=$ECLIPSE_VERS
 Name=Eclipse $ECLIPSE_VERS
@@ -92,10 +95,10 @@ endtext
 if [ -f $HOME/.local/share/applications/$LAUNCH_FILENAME ]; then
 	mv $HOME/.local/share/applications/$LAUNCH_FILENAME $HOME/.local/share/applications/$LAUNCH_FILENAME.b4_$DATE
 fi
-cp $HOME/Desktop/$LAUNCH_FILENAME $HOME/.local/share/applications/$LAUNCH_FILENAME
+cp $DESKTOP_DIR/$LAUNCH_FILENAME $HOME/.local/share/applications/$LAUNCH_FILENAME
 
 # set the permission to launch files
-chmod 700 $HOME/Desktop/$LAUNCH_FILENAME $HOME/.local/share/applications/$LAUNCH_FILENAME
+chmod 700 $DESKTOP_DIR/$LAUNCH_FILENAME $HOME/.local/share/applications/$LAUNCH_FILENAME
 
 
 # say bye

--- a/fix-eclipse-ubuntu-16.04-laf.sh
+++ b/fix-eclipse-ubuntu-16.04-laf.sh
@@ -53,23 +53,23 @@ DATE=`date|tr ' ' '_'`
 # Fetch location of desktop directory
 DESKTOP_DIR=$(xdg-user-dir DESKTOP)
 
-# Directory where the modified Ambiance-Eclipse theme is stored.
+# Directory where the modified Ambiance theme is stored.
 ECLIPSE_THEME_ROOT_DIR=$HOME/.eclipse/share/themes
-ECLIPSE_THEME_DIR=$ECLIPSE_THEME_ROOT_DIR/Ambiance-Eclipse
+ECLIPSE_THEME_DIR=$ECLIPSE_THEME_ROOT_DIR/Ambiance
 if [ -d $ECLIPSE_THEME_DIR ];then
 	mv $ECLIPSE_THEME_DIR $ECLIPSE_THEME_DIR".b4_"$DATE
 fi
 mkdir -p $ECLIPSE_THEME_DIR
 
-# copy Ambiance-Eclipse theme and modify tooltip color
+# copy Ambiance theme and modify tooltip color
 cp -rf /usr/share/themes/Ambiance/* $ECLIPSE_THEME_DIR
-sed -i 's/Ambiance/Ambiance-Eclipse/g' \
-	    $ECLIPSE_THEME_DIR/index.theme  \
-	    $ECLIPSE_THEME_DIR/metacity-1/metacity-theme-1.xml
 
 sed -i -r -e 's/@define-color tooltip_bg_color.*/@define-color tooltip_bg_color #f5f5c5;/'\
 	  -e 's/@define-color tooltip_fg_color.*/@define-color tooltip_fg_color #000000;/'\
 		$ECLIPSE_THEME_DIR/gtk-3.0/gtk-main.css
+
+sed -i -r -e 's/color: @tooltip_fg_color;/color: #000000;/'\
+    $ECLIPSE_THEME_DIR/gtk-3.0/gtk-widgets.css
 
 # also copy Default theme (somehow needed to keep button border
 # animations the same)
@@ -87,7 +87,7 @@ cat > $DESKTOP_DIR/$LAUNCH_FILENAME << endtext
 Version=$ECLIPSE_VERS
 Name=Eclipse $ECLIPSE_VERS
 Comment=Eclipse IDE $ECLIPSE_VERS
-Exec=env GTK_DATA_PREFIX=$HOME/.eclipse GTK_THEME=Ambiance-Eclipse $ECLIPSE_HOME/eclipse
+Exec=env GTK_DATA_PREFIX=$HOME/.eclipse GTK_THEME=Ambiance $ECLIPSE_HOME/eclipse
 Icon=$ECLIPSE_HOME/icon.xpm
 Terminal=false
 Type=Application


### PR DESCRIPTION
For me, Javadoc hovers and views were having their text displayed in the 'Ubuntu orange'. The latest commit in this request fixes this for me. The first two commits are small improvements for resp. using xdg-user-dir for finding out where the desktop directory resides and for also copying the default theme.
